### PR TITLE
doc: make: Fix version number of output API PDF

### DIFF
--- a/doc/api/Makefile
+++ b/doc/api/Makefile
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-PDF_NAME= "Quark Microcontroller Software Interface 1.1.pdf"
+PDF_NAME= "Quark Microcontroller Software Interface 1.2.pdf"
 
 V ?= 0
 


### PR DESCRIPTION
The PDF file produced by the documentation makefile and containing API
documentation was still named "Quark Microcontroller Software Interface
1.1.pdf".

This patch changes the documentation makefile in order to fix the
version number in the output filename.

Signed-off-by: Daniele Alessandrelli daniele.alessandrelli@intel.com
