### PR TITLE
Allow building using Link Time Optimizations (LTO)

### DIFF
--- a/drivers/rtc/qm_rtc.c
+++ b/drivers/rtc/qm_rtc.c
@@ -91,3 +91,13 @@ int qm_rtc_set_alarm(const qm_rtc_t rtc, const uint32_t alarm_val)
 
 	return 0;
 }
+
+int qm_rtc_read(const qm_rtc_t rtc, uint32_t *const value)
+{
+	QM_CHECK(rtc < QM_RTC_NUM, -EINVAL);
+	QM_CHECK(value != NULL, -EINVAL);
+	*value = QM_RTC[rtc].rtc_ccvr;
+
+	return 0;
+}
+


### PR DESCRIPTION
Proposed patch set fixes "missing linker plugin" issue when building with -flto flag enabled. Also it switches default debug optimization level to Og witch saves some memory while still being compatible with debugging. Plus I've noticed that qm_rtc.c is missing implementation of qm_rtc_read(). 
I hope that you'll find proposed changes useful.

Best,
K.
