### PR TITLE
aio: Add delay after power change to Analog Comparator.

### DIFF
--- a/drivers/comparator/qm_comparator.c
+++ b/drivers/comparator/qm_comparator.c
@@ -28,10 +28,12 @@
  */
 
 #include "qm_comparator.h"
+#include "clk.h"
 
 #if (HAS_SOC_CONTEXT_RETENTION)
 #include "power_states.h"
 #endif /* HAS_SOC_CONTEXT_RETENTION */
+#define ONE_MICROSECOND (1)
 
 static void (*callback)(void *, uint32_t) = NULL;
 static void *callback_data;
@@ -78,6 +80,9 @@ int qm_ac_set_config(const qm_ac_config_t *const config)
 	QM_SCSS_CMP->cmp_ref_sel = reference;
 	QM_SCSS_CMP->cmp_ref_pol = config->polarity;
 	QM_SCSS_CMP->cmp_pwr = config->power;
+
+	/* Provide some delay after power Change to Comparator*/
+	clk_sys_udelay(5 * ONE_MICROSECOND);
 
 	/* Clear all pending interrupts before we enable. */
 	QM_SCSS_CMP->cmp_stat_clr = 0x7FFFF;


### PR DESCRIPTION
Provide 5 micro sec delay after power change to analog
comparator to get it stable. If delay is not given,
we observed some instability and it generates random interrupt.

Jira: ZEP-1438(Zephyr RTOS)

Signed-off-by: Youvedeep Singh <youvedeep.singh@intel.com>